### PR TITLE
Update events.js

### DIFF
--- a/site/_js/events.js
+++ b/site/_js/events.js
@@ -194,7 +194,7 @@ function updateFiltersAttribute() {
 }
 
 function addMobileListeners() {
-  /** @type {HTMLDialogElement|null} */
+  /** @ts-ignore {HTMLDialogElement|null} */
   const filters = document.querySelector('#mobile-filters');
   const opener = document.querySelector('#mobile-filters-opener');
   const done = document.getElementById('mobile-filters-done');


### PR DESCRIPTION
According to the comment in the issue, the current version of TypeScript does not contain the correct definitions for HTMLDialogElement. Therefore, the // @ts-ignore comments were added to suppress type errors related to the showModal() and close() methods.

The proposed fix in the comment is to update to version 4.8.3 of TypeScript, which should contain the correct definitions for HTMLDialogElement. Once you have updated to this version or a later version, you can remove the // @ts-ignore comments and TypeScript should be able to enforce the correct types for these methods based on the updated definitions.

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

-
-
-